### PR TITLE
fix: overflow issue on write_depth function in utils/io.py

### DIFF
--- a/util/io.py
+++ b/util/io.py
@@ -186,7 +186,7 @@ def write_depth(path, depth, bits=1, absolute_depth=False):
         max_val = (2 ** (8 * bits)) - 1
 
         if depth_max - depth_min > np.finfo("float").eps:
-            out = max_val * (depth - depth_min) / (depth_max - depth_min)
+            out = (depth - depth_min) / (depth_max - depth_min) * max_val
         else:
             out = np.zeros(depth.shape, dtype=depth.dtype)
 


### PR DESCRIPTION
Sometimes multiplication ```max_val``` and ```(depth - depth_min)```  causes overflow when bits=1 because of ndarray dtype ```np.float16```.
To deal with this issue, I changed the order of multiplication. (Or we can use ```np.float32```)
This change has small impact on the output value.

```
original = max_val * (depth - depth_min) / (depth_max - depth_min)
suggestion = (depth - depth_min) / (depth_max - depth_min) * max_val 
original != suggestion 
```